### PR TITLE
Extra Regions

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,10 @@
 							<option value="USA" selected="selected">USA</option>
 							<option value="EUR">EUR</option>
 							<option value="JPN">JPN</option>
+							<option value="AUS">AUS</option>
+							<option value="CHN">EUR</option>
+							<option value="KOR">JPN</option>
+							<option value="TWN">AUS</option>
 						</select>
 						<label>Region</label>
 					</div>

--- a/scripts.js
+++ b/scripts.js
@@ -141,6 +141,8 @@ $("#settings input, #settings select").on('change', function() {
 		case '3DSXL':
 			if (region == 'JPN')
 				write(0, 16*5, 'Nintendo 3DS LL SPR-001('+region+')');
+			else if (region == 'CHN')
+				write(0, 16*5, 'iQue 3DS XL SPR-001('+region+')');
 			else
 				write(0, 16*5, 'Nintendo 3DS XL SPR-001('+region+')');
 			processor = 2; sd += ' SD'


### PR DESCRIPTION
There are additional regions to the three main regions listed: AUS (which can use EUR carts, but not EUR digital downloads), CHN (in which only the o3DS XL was released, under the iQue brand), KOR, and TWN.

In that regard, those regions have been added to the list of region options, and when generating the image, "Nintendo" switches to "iQue" for the original 3DS XL when the region is set to China.

It's still _technically_ possible to be CHN region and not iQue brand if you changed your region manually, but usually they go hand-in-hand and thus the CHN region option _should_ only be available to select for the o3DS XL, but I don't know how to do that.